### PR TITLE
Fix fonts not working

### DIFF
--- a/Piously.Game/Piously.Game.csproj
+++ b/Piously.Game/Piously.Game.csproj
@@ -17,10 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Textures\**\*.png" />
-    <EmbeddedResource Include="Tracks\**\*.wav" />
-    <EmbeddedResource Include="Samples\**\*.wav" />
-    <EmbeddedResource Include="Shaders\**\*.glslp" />
     <EmbeddedResource Include="Fonts\**\*.fnt" />
     <EmbeddedResource Include="Fonts\**\*.png" />
   </ItemGroup>

--- a/Piously.Game/Piously.Game.csproj
+++ b/Piously.Game/Piously.Game.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Fonts\**\*.fnt" />
-    <EmbeddedResource Include="Fonts\**\*.png" />
+    <EmbeddedResource Include="Resources\Fonts\**\*" />
   </ItemGroup>
 </Project>

--- a/Piously.Game/Piously.Game.csproj
+++ b/Piously.Game/Piously.Game.csproj
@@ -24,40 +24,4 @@
     <EmbeddedResource Include="Fonts\**\*.fnt" />
     <EmbeddedResource Include="Fonts\**\*.png" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Configuration\" />
-    <Folder Include="Database\" />
-    <Folder Include="Graphics\Backgrounds\" />
-    <Folder Include="Graphics\Cursor\" />
-    <Folder Include="Graphics\OpenGL\Textures\" />
-    <Folder Include="Graphics\Primitives\" />
-    <Folder Include="Graphics\Sprites\" />
-    <Folder Include="Graphics\Textures\" />
-    <Folder Include="Graphics\UserInterfaceV2\" />
-    <Folder Include="Graphics\UserInterface\" />
-    <Folder Include="IO\" />
-    <Folder Include="IPC\" />
-    <Folder Include="Online\API\Requests\Responses\" />
-    <Folder Include="Online\Chat\" />
-    <Folder Include="Overlays\AccountCreation\" />
-    <Folder Include="Overlays\Changelog\" />
-    <Folder Include="Overlays\Chat\Selection\" />
-    <Folder Include="Overlays\Chat\Tabs\" />
-    <Folder Include="Overlays\Comments\Buttons\" />
-    <Folder Include="Overlays\Dashboard\Friends\" />
-    <Folder Include="Overlays\Dialog\" />
-    <Folder Include="Overlays\OSD\" />
-    <Folder Include="Overlays\Profile\Header\Components\" />
-    <Folder Include="Overlays\Settings\Sections\General\" />
-    <Folder Include="Overlays\Settings\Sections\Maintenance\" />
-    <Folder Include="Overlays\Toolbar\" />
-    <Folder Include="Overlays\Volume\" />
-    <Folder Include="Resources\" />
-    <Folder Include="Screens\Backgrounds\" />
-    <Folder Include="Screens\Select\" />
-    <Folder Include="Updater\" />
-    <Folder Include="Users\Drawables\" />
-    <Folder Include="Utils\" />
-  </ItemGroup>
 </Project>

--- a/Piously.Game/PiouslyGameBase.cs
+++ b/Piously.Game/PiouslyGameBase.cs
@@ -19,7 +19,7 @@ namespace Piously.Game
         [BackgroundDependencyLoader]
         private void load(/*TextureStore store, AudioManager audio,*/)
         {
-            Resources.AddStore(new DllResourceStore(@"Piously.dll"));
+            Resources.AddStore(new DllResourceStore(@"Piously.Game.dll"));
 
             AddFont(Resources, @"Resources/Fonts/InkFree-Bold");
             AddFont(Resources, @"Resources/Fonts/InkFree");


### PR DESCRIPTION
As promised on discord, here are the fonts being fixed.

![2020-10-30-162957_1920x1012_scrot](https://user-images.githubusercontent.com/20418176/97724417-2c5f6800-1acd-11eb-8584-5a743cea771a.png)

Taking it from the top:

* The path references in the `.csproj` were all wrong. Not a single folder listed actually exists in your project tree. Aside from this causing my rider instance to show a multitude of errors due to that, it also meant that the font resources weren't getting embedded in the `Piously.Game` assembly, and as such it would not be possible to load them via any `DllResourceStore`, as there weren't being added to any DLL in the first place.

  I suspect this is due to you copying the project files from the lazer repository verbatim without understanding what they do instead of using the [templates](https://github.com/ppy/osu-framework/tree/master/osu.Framework.Templates).

* Secondly, the dll specified when creating the resource store was also wrong. You placed the resources in the `Piously.Game` project, which means that if embedded correctly, they would be placed in `Piously.Game.dll`, and not `Piously.dll`, as the latter is actually produced by the `Piously.Desktop` project.

Please note that I will not fix things for you again, and I or the team are not able to provide this level of basic counsel going forward. I strongly encourage you to get acquainted with C# better, to at least be able to debug things like this on your own.