### PR TITLE
Update HexagonalContainer to antialias

### DIFF
--- a/Piously.Game/Graphics/Containers/HexagonalContainer.cs
+++ b/Piously.Game/Graphics/Containers/HexagonalContainer.cs
@@ -43,20 +43,18 @@ namespace Piously.Game.Graphics.Containers
             Vector2 norm = screenSpacePos - this.ScreenSpaceDrawQuad.TopLeft;
             norm = new Vector2(norm.X / this.ScreenSpaceDrawQuad.Width, norm.Y / this.ScreenSpaceDrawQuad.Height); // apparently we can't divide Vector2s?
             norm = (norm - new Vector2(0.5f)) * 2;
+            
+            // hexagons are horizontally and vertically symmetrical, so we only have to test one quadrant :)
+            norm = new Vector2(Math.Abs(norm.X), Math.Abs(norm.Y));
 
-            if (Math.Abs(norm.Y) > sin_pi_over_3)
+            if (norm.Y > sin_pi_over_3)
             {
-                return false; // top and bottom bounds
+                return false; // top bound
             }
 
-            if (Math.Abs(norm.Y) > -tan_pi_over_3 * (norm.X - 1))
+            if (norm.Y > -tan_pi_over_3 * (norm.X - 1))
             {
-                return false; // right bounds
-            }
-
-            if (Math.Abs(norm.Y) > tan_pi_over_3 * (norm.X + 1))
-            {
-                return false; // right bounds
+                return false; // right bound
             }
 
             return true;
@@ -103,6 +101,8 @@ namespace Piously.Game.Graphics.Containers
 
                 using (BindFrameBuffer(target))
                 {
+                    float resolution = Math.Max(this.Source.ScreenSpaceDrawQuad.Width, this.Source.ScreenSpaceDrawQuad.Height); // shh
+                    hexagonShader.GetUniform<float>("g_Resolution").UpdateValue(ref resolution);
                     hexagonShader.Bind();
                     DrawFrameBuffer(current, new RectangleF(0, 0, current.Texture.Width, current.Texture.Height), ColourInfo.SingleColour(Color4.White));
                     hexagonShader.Unbind();

--- a/Piously.Game/Resources/Shaders/sh_TextureHexagon.fs
+++ b/Piously.Game/Resources/Shaders/sh_TextureHexagon.fs
@@ -7,31 +7,37 @@ varying mediump vec2 v_TexCoord;
 
 uniform lowp sampler2D m_Sampler;
 
-bool withinHexagon(mediump vec2 coord)
+// this is the "size" of the object in screen space--specifically max(width, height).
+uniform highp float g_Resolution;
+
+// a visual demonstration of this calculation can be found at https://www.desmos.com/calculator/vihhpowcrb.
+highp float calculateHexagonDistance(mediump vec2 coord)
 {
     mediump vec2 tmp = (coord - vec2(0.5));
-    mediump vec2 norm = vec2(tmp.x * 2.0, tmp.y * 2.0);
+    mediump vec2 norm = vec2(abs(tmp.x * 2.0), abs(tmp.y * 2.0));
 
-    if (abs(norm.y) > SIN_PI_OVER_3) {
-        return false; // top and bottom bounds
-    }
+    // d1 is the distance from coord to the right bound.
+    highp float d1 = (-TAN_PI_OVER_3 * norm.x - norm.y + TAN_PI_OVER_3) / 2.0;
+    // d1 is the distance from coord to the top bound.
+    highp float d2 = SIN_PI_OVER_3 - norm.y;
 
-    if (abs(norm.y) > -TAN_PI_OVER_3 * (norm.x - 1.0)) {
-        return false; // right bounds
-    }
-
-    if (abs(norm.y) > TAN_PI_OVER_3 * (norm.x + 1.0)) {
-        return false; // right bounds
-    }
-
-    return true;
+    return min(d1, d2);
 }
 
 void main(void)
 {
     gl_FragColor = toSRGB(texture2D(m_Sampler, v_TexCoord));
 
-    if (!withinHexagon(v_TexCoord)) {
-        gl_FragColor.a = 0.0;
+    // distance in pixels from the edge of the hexagon (assuming a square draw quad >_>).
+    highp float distance = calculateHexagonDistance(v_TexCoord) * g_Resolution / 2.0;
+
+    if (distance <= 0)
+    {
+        discard;
+    }
+    else
+    {
+        // blending range is implicitly 1.0.
+        gl_FragColor.a *= distance;
     }
 }

--- a/Piously.MenuTests/Visual/TestSceneHexagonContainer.cs
+++ b/Piously.MenuTests/Visual/TestSceneHexagonContainer.cs
@@ -13,11 +13,13 @@ namespace Piously.MenuTests.Visual
 {
     public class TestSceneHexagonContainer : TestScene
     {
+        private readonly Container container;
+
         public TestSceneHexagonContainer()
         {
             this.AddRange(new Drawable[]
             {
-                new Container
+                this.container = new Container
                 {
                     Size = new Vector2(256),
                     Children = new Drawable[]
@@ -34,6 +36,8 @@ namespace Piously.MenuTests.Visual
                     }
                 }
             });
+
+            this.AddSliderStep(@"Resize", 64, 768, 256, value => this.container.ResizeTo(value));
         }
 
         private class TestHexagonalContainer : HexagonalContainer


### PR DESCRIPTION
Comparison:

![image](https://user-images.githubusercontent.com/1782081/98071672-03b2d780-1e19-11eb-9819-c541d4e916e4.png)

This isn't *true* antialiasing (I'd rather call it smoothing), but it looks pretty much identical (and, as far as I'm aware, works off the same principle as `CompositeDrawable`.) A visual demonstration of the math behind this can be found [here](https://www.desmos.com/calculator/vihhpowcrb) (drag around the red point), and is explained in detail below.

<details>
<summary>Math</summary>
The core of the shader finds the distance from any fragment to the edge of the hexagon, then blends between alpha 0 and 1 for a distance of one pixel from the edge.

Regular hexagons have horizontal and vertical symmetry, which means that we only need to do math for the first (upper-left) quadrant, and the results can be mirrored for the other three quadrants.

Finding the distance to the edge of a (regular?) polygon is equivalent to finding the distance to every edge of the polygon and taking the minimum of these values. Since the first quadrant only contains two edges of the hexagon, this is only two distance calculations.

The right edge can be expressed as follows:

![equation](https://user-images.githubusercontent.com/1782081/98069428-9c465900-1e13-11eb-9e16-96eb7ee402f6.png)

The top edge can be expressed as follows:

![equation](https://user-images.githubusercontent.com/1782081/98069410-8fc20080-1e13-11eb-9758-4495f56aa0fe.png)

The distance between a point and a line is given as follows:

![equation](https://user-images.githubusercontent.com/1782081/98069376-7620b900-1e13-11eb-9c50-651394871010.png)

This requires us to rephrase the edges in the form ![equation](https://user-images.githubusercontent.com/1782081/98069521-d6aff600-1e13-11eb-9f38-379e405b08ea.png), which can be done as follows for the right and top edges respectively:

![equation](https://user-images.githubusercontent.com/1782081/98069641-1aa2fb00-1e14-11eb-8bc0-6c272f7cb44a.png)
![equation](https://user-images.githubusercontent.com/1782081/98069673-2f7f8e80-1e14-11eb-9193-afc12b79c244.png)

This yields these two distance functions given a point ![equation](https://user-images.githubusercontent.com/1782081/98069773-74a3c080-1e14-11eb-9c1d-523e13f21c5c.png):

![equation](https://user-images.githubusercontent.com/1782081/98069890-c8aea500-1e14-11eb-8a66-268003b16034.png)
![equation](https://user-images.githubusercontent.com/1782081/98069952-001d5180-1e15-11eb-95d5-45a66a47d019.png)

Because ![equation](https://user-images.githubusercontent.com/1782081/98070286-b4b77300-1e15-11eb-9167-9ad7b6a58d6f.png) evaluates to ![equation](https://user-images.githubusercontent.com/1782081/98070172-791ca900-1e15-11eb-9710-38d92d3368ce.png) and ![equation](https://user-images.githubusercontent.com/1782081/98070617-52ab3d80-1e16-11eb-8be0-8d864bb5dbc5.png) evaluates to ![equation](https://user-images.githubusercontent.com/1782081/98070655-65257700-1e16-11eb-8a67-0c2b0ddf904e.png), we can simplify, resulting in the following two final equations:

![equation](https://user-images.githubusercontent.com/1782081/98070469-15df4680-1e16-11eb-9137-ab0792664a11.png)
![equation](https://user-images.githubusercontent.com/1782081/98070495-2394cc00-1e16-11eb-8a66-4b8f9d3f839e.png)

We can take the minimum of these two values to find the distance to the edge of the hexagon in the first quadrant.

This was super fun to work on!
</details>

## Notes

* The performance impact of the updated shader should be negligible because of optimization.
* The positional input checks of `HexagonalContainer` now also use symmetry to its advantage, reducing the number of checks from three to two. An insignificant improvement in performance, but it does feel nice. 😊
* This PR also adds a slider control to `TestSceneHexagonContainer` which changes the container's size, to verify that the smoothing functions properly at all game scales and resolutions.